### PR TITLE
Made oopsie. Fixed max health values.

### DIFF
--- a/module/C2D10Actor.js
+++ b/module/C2D10Actor.js
@@ -8,8 +8,12 @@ export default class C2D10Actor extends Actor {
   }
 
   async prepareDerivedData() {
+    // Derive health values.
     const maxStrain = parseInt(this.system.talents.physical.endurance + 3);
     const maxStress = parseInt(this.system.talents.mental.willpower + this.system.talents.social.poise);
+
+    this.system.health.strain.max = maxStrain;
+    this.system.health.stress.max = maxStress;
 
     this.system.health.crisis.physical = this.system.health.strain.critical;
     this.system.health.crisis.mental = this.system.health.stress.critical;

--- a/system.json
+++ b/system.json
@@ -1,7 +1,7 @@
 {
     "id": "c2d10",
     "title": "Celenia D10 Roleplaying System - 2nd Edition",
-    "version": 0.494,
+    "version": 0.495,
     "compatibility": {
         "minimum": "10",
         "verified": "10.286",


### PR DESCRIPTION
- Testing updating the token bars to show only crit.
- Increased opacity on the keeper control numbers.
- Updated pause logo with a circle.
- Fixed token health display.
- Updated version number for main merge.
- Implemented impairment to rolls. Remove Pass/Fail in chat. Added impairment display on sheet.
- Removed pass/fail in roll notation (chat)
- Forgot to actually update max values.
