### PR TITLE
Armor and Weapons added to sheet.

### DIFF
--- a/c2d10-style.css
+++ b/c2d10-style.css
@@ -635,6 +635,10 @@ table input {
   box-shadow: none !important;
   color: inherit !important;
 }
+.c2d10.sheet input.c2d10-sheet-entry,
+.c2d10.item-sheet input.c2d10-sheet-entry {
+  font-family: Quantum, sans-serif;
+}
 .c2d10.sheet .align-right,
 .c2d10.item-sheet .align-right {
   text-align: right;

--- a/c2d10.js
+++ b/c2d10.js
@@ -188,7 +188,7 @@ Hooks.once("init", function() {
   Items.unregisterSheet("core", ItemSheet);
   Items.registerSheet("c2d10", C2D10ItemSheet, {
     makeDefault: true,
-    types: ["asset", "power", "trait", "variant"],
+    types: ["armor", "asset", "power", "trait", "variant", "weapon"],
     label: "C2D10 Item Sheet"
   });
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -143,8 +143,12 @@
         },
         "asset": {
             "name": "Name",
+            "ablation": "Ablation",
+            "deflection": "Deflection",
             "description": "Description",
             "assetType": "Type",
+            "critical": "Critical",
+            "superficial": "Superficial",
             "value": "Value",
             "quality": "Quality"
         },

--- a/less/sheets.less
+++ b/less/sheets.less
@@ -16,6 +16,10 @@
         color: inherit !important;
     }
 
+    input.c2d10-sheet-entry {
+        font-family: @h1;
+    }
+
     .align-right {
         text-align: right;
     }

--- a/module/sheets/C2D10ActorSheet.js
+++ b/module/sheets/C2D10ActorSheet.js
@@ -31,7 +31,7 @@ export default class C2D10ActorSheet extends ActorSheet {
     /**
      * Items
      */
-    sheetData.assets = sheetData.items.filter(p => p.type === "asset");
+    sheetData.assets = sheetData.items.filter(p => p.type === "asset" || p.type === "armor" || p.type === "weapon" );
     sheetData.virtues = sheetData.items.filter(p => p.type === "trait" && p.system.traitType === "virtue");
     sheetData.vices = sheetData.items.filter(p => p.type === "trait" && p.system.traitType === "vice");
     sheetData.powers = sheetData.items.filter(p => p.type === "power");

--- a/system.json
+++ b/system.json
@@ -1,7 +1,7 @@
 {
     "id": "c2d10",
     "title": "Celenia D10 Roleplaying System - 2nd Edition",
-    "version": 0.495,
+    "version": 0.496,
     "compatibility": {
         "minimum": "10",
         "verified": "10.286",

--- a/template.json
+++ b/template.json
@@ -106,10 +106,22 @@
                 "health",
                 "talents",
                 "skills"
-            ]
+            ],
+            "equipment": {
+                "armor": "",
+                "weapon": ""
+            }
         }
     },
     "Item": {
+        "templates": {
+            "coreAsset": {
+                "description": "This is a description",
+                "value": 0,
+                "quality": 0
+            }
+        },
+
         "types": [
             "armor",
             "asset",
@@ -119,17 +131,18 @@
             "weapon"
         ],
         "armor": {
-            "description": "",
+            "templates": [
+                "coreAsset"
+            ],
+            "ablation": 0,
             "deflection": 0,
-            "penalty": "None",
-            "soak": 0,
-            "value": 0
+            "penalty": "None"
         },
         "asset": {
-            "assetType": "",
-            "description": "",
-            "quality": 0,
-            "value": 0
+            "templates": [
+                "coreAsset"
+            ],
+            "assetType": ""
         },
         "power": {
             "description": "",
@@ -154,6 +167,9 @@
             "traitType": "virtue"
         },
         "weapon": {
+            "templates": [
+                "coreAsset"
+            ],
             "critical": 0,
             "superficial": 0,
             "penalty": "None"            

--- a/template.json
+++ b/template.json
@@ -111,11 +111,20 @@
     },
     "Item": {
         "types": [
+            "armor",
             "asset",
             "power",
             "variant",
-            "trait"
+            "trait",
+            "weapon"
         ],
+        "armor": {
+            "description": "",
+            "deflection": 0,
+            "penalty": "None",
+            "soak": 0,
+            "value": 0
+        },
         "asset": {
             "assetType": "",
             "description": "",
@@ -143,6 +152,11 @@
         "trait": {
             "level": 0,
             "traitType": "virtue"
+        },
+        "weapon": {
+            "critical": 0,
+            "superficial": 0,
+            "penalty": "None"            
         }
     }
 }

--- a/templates/sheets/armor-sheet.hbs
+++ b/templates/sheets/armor-sheet.hbs
@@ -1,0 +1,60 @@
+<form class="sheet-main-content c2d10 sheet flex-col flex-start">
+    <section class="c2d10-sheet-header-box">
+        <h1>
+            <input name="name" type="text" value="{{item.name}}" placeholder="{{localize "c2d10.asset.name"}}" />
+        </h1>
+        <h3 class="c2d10-alert">
+            <input name="system.assetType" type="text" value="{{system.assetType}}" placeholder="{{localize "c2d10.asset.assetType"}}" />
+        </h3>
+    </section>
+    <section>
+        <div class="c2d10-subsection flex-row flex-between">
+            <div class="w-80 c2d10-contentbox {{#if showEffects}}fancy-effects{{/if}} c2d10-asset-textarea">
+                <textarea name="system.description">{{system.description}}</textarea>
+            </div>
+            <div class="flex-col flex-start">
+                <div class="c2d10-contentbox {{#if showEffects}}fancy-effects{{/if}} w-fit">
+                    <div class="image-box flex-row flex-center">
+                        <img class="item-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" height="145px" />
+                    </div>
+                </div>
+                <div class="flex-col flex-start w-20 value-box c2d10-contentbox {{#if showEffects}}fancy-effects{{/if}}">
+                    <table>
+                        <colgroup>
+                            <col class="w-50">
+                            <col class="w-50">
+                        </colgroup>
+                        <tr>
+                            <th class="table-no-border">
+                                {{localize "c2d10.asset.quality"}}
+                            </th>
+                            <td class="flex-row table-no-border resource-row" data-id="quality" data-tooltip="{{localize "c2d10.sheet.dot-tooltip"}}">
+                                {{#dots system.quality 5}}{{/dots}}
+                            </td>
+                        </tr>
+                        <tr>
+                            <th class="table-no-border">
+                                {{localize "c2d10.asset.value"}}
+                            </th>
+                            <td class="flex-row table-no-border resource-row" data-id="value" data-tooltip="{{localize "c2d10.sheet.dot-tooltip"}}">
+                                {{#dots system.value 5}}{{/dots}}
+                            </td>
+                        </tr>
+                        <tr>
+                            <th class="table-no-border">{{localize "c2d10.asset.ablation"}}</th>
+                            <td class="table-no-border">
+                                 <input class="c2d10-sheet-entry" name="system.ablation" type="text" value="{{system.ablation}}" placeholder="{{localize "c2d10.asset.ablation"}}" />
+                            </td>
+                        </tr>
+                        <tr>
+                            <th class="table-no-border">{{localize "c2d10.asset.deflection"}}</th>
+                            <td class="table-no-border">
+                                <input class="c2d10-sheet-entry" name="system.deflection" type="text" value="{{system.deflection}}" placeholder="{{localize "c2d10.asset.deflection"}}" />
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </section>
+</form>

--- a/templates/sheets/weapon-sheet.hbs
+++ b/templates/sheets/weapon-sheet.hbs
@@ -1,0 +1,60 @@
+<form class="sheet-main-content c2d10 sheet flex-col flex-start">
+    <section class="c2d10-sheet-header-box">
+        <h1>
+            <input name="name" type="text" value="{{item.name}}" placeholder="{{localize "c2d10.asset.name"}}" />
+        </h1>
+        <h3 class="c2d10-alert">
+            <input name="system.assetType" type="text" value="{{system.assetType}}" placeholder="{{localize "c2d10.asset.assetType"}}" />
+        </h3>
+    </section>
+    <section>
+        <div class="c2d10-subsection flex-row flex-between">
+            <div class="w-80 c2d10-contentbox {{#if showEffects}}fancy-effects{{/if}} c2d10-asset-textarea">
+                <textarea name="system.description">{{system.description}}</textarea>
+            </div>
+            <div class="flex-col flex-start">
+                <div class="c2d10-contentbox {{#if showEffects}}fancy-effects{{/if}} w-fit">
+                    <div class="image-box flex-row flex-center">
+                        <img class="item-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" height="145px" />
+                    </div>
+                </div>
+                <div class="flex-col flex-start w-20 value-box c2d10-contentbox {{#if showEffects}}fancy-effects{{/if}}">
+                    <table>
+                        <colgroup>
+                            <col class="w-50">
+                            <col class="w-50">
+                        </colgroup>
+                        <tr>
+                            <th class="table-no-border">
+                                {{localize "c2d10.asset.quality"}}
+                            </th>
+                            <td class="flex-row table-no-border resource-row" data-id="quality" data-tooltip="{{localize "c2d10.sheet.dot-tooltip"}}">
+                                {{#dots system.quality 5}}{{/dots}}
+                            </td>
+                        </tr>
+                        <tr>
+                            <th class="table-no-border">
+                                {{localize "c2d10.asset.value"}}
+                            </th>
+                            <td class="flex-row table-no-border resource-row" data-id="value" data-tooltip="{{localize "c2d10.sheet.dot-tooltip"}}">
+                                {{#dots system.value 5}}{{/dots}}
+                            </td>
+                        </tr>
+                        <tr>
+                            <th class="table-no-border">{{localize "c2d10.asset.superficial"}}</th>
+                            <td class="table-no-border">
+                                 <input class="c2d10-sheet-entry" name="system.superficial" type="text" value="{{system.superficial}}" placeholder="{{localize "c2d10.asset.superficial"}}" />
+                            </td>
+                        </tr>
+                        <tr>
+                            <th class="table-no-border">{{localize "c2d10.asset.critical"}}</th>
+                            <td class="table-no-border">
+                                <input class="c2d10-sheet-entry" name="system.critical" type="text" value="{{system.critical}}" placeholder="{{localize "c2d10.asset.critical"}}" />
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </section>
+</form>


### PR DESCRIPTION
- Testing updating the token bars to show only crit.
- Increased opacity on the keeper control numbers.
- Updated pause logo with a circle.
- Fixed token health display.
- Updated version number for main merge.
- Implemented impairment to rolls. Remove Pass/Fail in chat. Added impairment display on sheet.
- Removed pass/fail in roll notation (chat)
- Forgot to actually update max values.
- Added Armor and Weapon types. No functionality or sheets yet. Just added to template.
- Added armor and weapon sheets. TODO: Make a selector for damage/absorption type. TODO: Add a way to equip armor and weapons on a character.
- Added so armor and weapons are shown in the assets tab
