### PR TITLE
Crisis and pool changes

### DIFF
--- a/c2d10-style.css
+++ b/c2d10-style.css
@@ -1074,8 +1074,8 @@ table input {
   border: none !important;
   box-shadow: none !important;
   color: inherit !important;
-  height: 35px !important;
   font-size: 1.25rem;
+  font-family: Quantum, sans-serif;
 }
 .c2d10-dialog select {
   border: none;

--- a/lang/en.json
+++ b/lang/en.json
@@ -58,6 +58,7 @@
             "skill": "Skill",
             "skills": "Skills",
             "talents": "Talents",
+            "trait": "Trait",
             "traits": "Traits",
             "virtue": "Virtue",
             "vice": "Vice",

--- a/less/dialogs.less
+++ b/less/dialogs.less
@@ -13,9 +13,10 @@
         border: none !important;
         box-shadow: none !important;
         color: inherit !important;
-        height: 35px !important;
         font-size: @size[large];
+        font-family: @h1;
     }
+
 
     select {
         border: none;

--- a/module/C2D10Actor.js
+++ b/module/C2D10Actor.js
@@ -15,9 +15,8 @@ export default class C2D10Actor extends Actor {
     this.system.health.strain.max = maxStrain;
     this.system.health.stress.max = maxStress;
 
-    this.system.health.crisis.physical = this.system.health.strain.critical;
-    this.system.health.crisis.mental = this.system.health.stress.critical;
-    this.system.health.crisis.max = 10;
+    const crisisValue = parseInt(this.system.health.strain.critical + this.system.health.stress.critical);
+    this.system.health.crisis = crisisValue <= 5 ? crisisValue : 5;
 
     // Combine the two types of damage and inverse them in order to show a reduction bar on tokens.
     const strainValue = parseInt(this.system.health.strain.superficial + this.system.health.strain.critical);

--- a/module/C2D10Dice.js
+++ b/module/C2D10Dice.js
@@ -206,12 +206,15 @@ const _doRoll = async rollData => {
   const bonusDice = getDice();
   let pool = rollData.parent ? parseInt(rollData.pool + parentLevel + bonusDice) : rollData.pool + bonusDice;
   if (rollData.focus) pool += 1;
-  if (pool > 10) pool = 10;
+  if (rollData.trait > 0) pool += rollData.trait;
+
   const crisis = rollData.crisis > pool ? pool : rollData.crisis;
   const targetNumber = 7;
   const rollFormula = `${pool}d10cs>=${targetNumber}`;
   const theRoll = new Roll(rollFormula);
   const DC = rollData.DC;
+
+  console.log("RollData", rollData);
 
 
   // Execute the roll
@@ -317,9 +320,10 @@ export async function skillTest(crisis, item, pool, talents, actorId, group) {
 
   // Populate the needed rolldata
   rollData.talentsList = c2d10.allTalents;
-  rollData.pool = pool;
+  rollData.pool = parseInt(pool);
   rollData.item = item;
-  rollData.crisis = crisis;
+  rollData.crisis = parseInt(crisis);
+  rollData.trait = 0;
   rollData.id = actorId;
   rollData.DC = game.settings.get("c2d10", "DC");
   rollData.talents = talents;
@@ -340,10 +344,11 @@ export async function skillTest(crisis, item, pool, talents, actorId, group) {
         roll: {
           label: "Roll!",
           callback: html => {
-            rollData.pool = html.find("input#pool").val() <= 5 ? parseInt(html.find("input#pool").val()) : 5;
-            rollData.crisis = html.find("input#crisis").val();
+            rollData.pool = parseInt(html.find("input#pool").val() <= 5 ? parseInt(html.find("input#pool").val()) : 5);
+            rollData.crisis = parseInt(html.find("input#crisis").val());
             rollData.parent = html.find("select#parent").val();
             rollData.focus = html.find("input#focus")[0].checked;
+            rollData.trait = parseInt(html.find("input#trait").val());
             // Call the roll function
             _doRoll(rollData);}
         }
@@ -370,6 +375,7 @@ export async function powerTest(crisis, item, pool, talents, actorId) {
   rollData.pool = pool;
   rollData.item = item;
   rollData.crisis = crisis;
+  rollData.trait = 0;
   rollData.id = actorId;
   rollData.DC = game.settings.get("c2d10", "DC");
   rollData.talents = talents;
@@ -389,10 +395,11 @@ export async function powerTest(crisis, item, pool, talents, actorId) {
         roll: {
           label: "Roll!",
           callback: html => {
-            rollData.pool = html.find("input#pool").val() <= 5 ? parseInt(html.find("input#pool").val()) : 5;
-            rollData.crisis = html.find("input#crisis").val();
+            rollData.pool = parseInt(html.find("input#pool").val() <= 5 ? parseInt(html.find("input#pool").val()) : 5);
+            rollData.crisis = parseInt(html.find("input#crisis").val());
             rollData.parent = html.find("select#parent").val();
             rollData.focus = html.find("input#focus")[0].checked;
+            rollData.trait = parseInt(html.find("input#trait").val());
             // Call the roll function
             _doRoll(rollData);}
         }

--- a/module/sheets/C2D10ActorSheet.js
+++ b/module/sheets/C2D10ActorSheet.js
@@ -412,7 +412,7 @@ export default class C2D10ActorSheet extends ActorSheet {
     const sys = this.getData().system;
     let pool = parseInt(sys.talents[dataset.group][dataset.id] * 2);
     const actorId = this.actor.id;
-    const crisis = dataset.group === "physical" ? sys.health.crisis.physical : sys.health.crisis.mental;
+    const crisis = sys.health.crisis;
 
     if (dataset.group === "physical" && sys.health.physicalImpairment) {
       pool -= 2;
@@ -444,7 +444,7 @@ export default class C2D10ActorSheet extends ActorSheet {
     let pool = sys.skills[dataset.group][dataset.id];
     const talents = this.getData().talents;
     const actorId = this.actor.id;
-    const crisis = dataset.group === "physical" ? sys.health.crisis.physical : sys.health.crisis.mental;
+    const crisis = sys.health.crisis;
 
     if (dataset.group === "physical" && sys.health.physicalImpairment) {
       pool -= 2;
@@ -478,7 +478,7 @@ export default class C2D10ActorSheet extends ActorSheet {
     let pool = power.system.level;
     const talents = this.getData().talents;
     const actorId = this.actor.id;
-    const crisis = dataset.group === "physical" ? sys.health.crisis.physical : sys.health.crisis.mental;
+    const crisis = sys.health.crisis;
 
     if (sys.health.mentalImpairment) {
       pool -= 2;

--- a/system.json
+++ b/system.json
@@ -1,53 +1,49 @@
 {
-    "id": "c2d10",
-    "title": "Celenia D10 Roleplaying System - 2nd Edition",
-    "version": 0.496,
-    "compatibility": {
-        "minimum": "10",
-        "verified": "10.286",
-        "maximum": "10"
-    },
-    "authors": [
-        {
-            "name": "The Toblin",
-            "url": "http://www.celenia.se",
-            "email": "tobias@celenia.se",
-            "discord": "Toblin#2367"
-        }
-    ],
-    "relationships": {
-        "systems": [],
-        "requires": []
-    },
-    "esmodules": [
-        "c2d10.js"
-    ],
-    "styles": [
-        "c2d10-style.css"
-    ],
-    "languages": [
-        {
-            "lang": "en",
-            "name": "English",
-            "path": "lang/en.json",
-            "title": "Celenia D10 Roleplaying System - 2nd Edition",
-            "description": "A narratively focused RPG system, based on Vampire the Masquerade, Dune and Ten Candles. Focuses on narrative and player agency."
-        }
-    ],
-    "media": [
-        {
-            "type": "cover",
-            "url": "https://www.worldanvil.com/media/cache/cover/uploads/images/0cf18b9b9afa7979c1555bb8d8713da2.webp",
-            "caption": "Celenia D10 RPG System 2nd Edition"            
-        }
-    ],
-    "socket": false,
-    "url": "https://github.com/The-Toblin/c2d10-foundry-vtt/",
-    "manifest": "https://raw.githubusercontent.com/The-Toblin/c2d10-foundry-vtt/main/system.json",
-    "download": "https://github.com/The-Toblin/c2d10-foundry-vtt/archive/refs/heads/main.zip",
-    "protected": false,
-    "gridDistance": "1.5",
-    "gridUnits": "m",
-    "primaryTokenAttribute": "strain",
-    "secondaryTokenAttribute": "stress"
+  "id": "c2d10",
+  "title": "Celenia D10 Roleplaying System - 2nd Edition",
+  "version": "0.497",
+  "compatibility": {
+    "minimum": "10",
+    "verified": "10.286",
+    "maximum": "10"
+  },
+  "authors": [
+    {
+      "name": "The Toblin",
+      "url": "http://www.celenia.se",
+      "email": "tobias@celenia.se",
+      "discord": "Toblin#2367",
+      "flags": {}
+    }
+  ],
+  "esmodules": [
+    "c2d10.js"
+  ],
+  "styles": [
+    "c2d10-style.css"
+  ],
+  "languages": [
+    {
+      "lang": "en",
+      "name": "English",
+      "path": "lang/en.json",
+      "flags": {}
+    }
+  ],
+  "media": [
+    {
+      "type": "cover",
+      "url": "https://www.worldanvil.com/media/cache/cover/uploads/images/0cf18b9b9afa7979c1555bb8d8713da2.webp",
+      "caption": "Celenia D10 RPG System 2nd Edition",
+      "loop": false,
+      "flags": {}
+    }
+  ],
+  "url": "https://github.com/The-Toblin/c2d10-foundry-vtt/",
+  "manifest": "https://raw.githubusercontent.com/The-Toblin/c2d10-foundry-vtt/main/system.json",
+  "download": "https://github.com/The-Toblin/c2d10-foundry-vtt/archive/refs/heads/main.zip",
+  "gridDistance": 1.5,
+  "gridUnits": "m",
+  "primaryTokenAttribute": "strain",
+  "secondaryTokenAttribute": "stress"
 }

--- a/templates/dialogs/roll-test-dialog.hbs
+++ b/templates/dialogs/roll-test-dialog.hbs
@@ -25,13 +25,28 @@
              />
         </div>
     </div>
-    <div class="c2d10-subsection">
-        <h3 class="align-center c2d10-capitalize">
-            {{localize "c2d10.sheet.focus"}}
-        </h3>
-        <div class="c2d10-contentbox flex-row flex-center c2d10-dark-background">
-            <div style="position: relative;">
-                <input id="focus" name="focus" type="checkbox" value="off"/>
+    <div class="flex-row flex-between">
+        <div class="c2d10-subsection w-40 h-100">
+            <h3 class="align-center c2d10-capitalize">
+                {{localize "c2d10.sheet.focus"}}
+            </h3>
+            <div class="c2d10-contentbox flex-row flex-center c2d10-dark-background">
+                <div style="position: relative;">
+                    <input id="focus" name="focus" type="checkbox" value="off"/>
+                </div>
+            </div>
+        </div>
+        <div class="c2d10-subsection w-60 h-100">
+            <h3 class="align-center c2d10-capitalize">
+                {{localize "c2d10.sheet.trait"}}
+            </h3>
+            <div class="c2d10-contentbox flex-row flex-center c2d10-dark-background">
+               <input class="align-center"
+                id="trait"
+                type="text"
+                value="{{trait}}"
+                placeholder="{{localize "c2d10.sheet.trait"}}"
+             />
             </div>
         </div>
     </div>

--- a/templates/partials/sheet-tabs/actor-info.hbs
+++ b/templates/partials/sheet-tabs/actor-info.hbs
@@ -71,9 +71,9 @@
                         {{localize "c2d10.resources.crisis"}}
                     </h3>
                 <div>
-                    <div class="dot-container flex-row resource-row crisis-number crisis-alert"
+                    <div class="dot-container flex-row resource-row crisis-number crisis-alert {{#if (gt system.health.crisis 3)}} crisis-bad{{/if}}"
                     data-type="health" data-id="crisis" data-pass="true" data-tooltip="{{localize "c2d10.sheet.dot-tooltip"}}">
-                        {{system.health.crisis.physical}} {{system.health.crisis.mental}}
+                        {{system.health.crisis}}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
- Testing updating the token bars to show only crit.
- Increased opacity on the keeper control numbers.
- Updated pause logo with a circle.
- Fixed token health display.
- Updated version number for main merge.
- Implemented impairment to rolls. Remove Pass/Fail in chat. Added impairment display on sheet.
- Removed pass/fail in roll notation (chat)
- Forgot to actually update max values.
- Added Armor and Weapon types. No functionality or sheets yet. Just added to template.
- Added armor and weapon sheets. TODO: Make a selector for damage/absorption type. TODO: Add a way to equip armor and weapons on a character.
- Added so armor and weapons are shown in the assets tab
- Unified Crisis to one. Capped Crisis to 5. Added trait bonus to roll dialog. Uncapped Pool size.
